### PR TITLE
Added a question to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ cf push <YOUR_APP_NAME> -m 128M -b https://github.com/ephoning/heroku-buildpack-
 Notes
 -----
 2014/02/18: The offical Heroku buildpack seems not to be working with Cloud Foundry.
+
+Question
+--------
+Have you tried using Python 3? If I edit runtime.txt, I can upgrade to python-2.7.6 on IBM BlueMix with no problems.
+
+However if I attempt python-3.4.0 or 3.3.0 I get the message File “/tmp/buildpacks/heroku-buildpack-python/vendor/bpwatch/bpwatch.zip/bp_cli.py”, line 37
+print get_state()
+
+The problem is that print() is a function in Python3 so the syntax must be print(get_state()) for Python3 to be happy. (e.g. In Python3 the parentheses are not optional).
+


### PR DESCRIPTION
Have you tried using Python 3? If I edit runtime.txt, I can upgrade to python-2.7.6 on IBM BlueMix with no problems.

However if I attempt python-3.4.0 or 3.3.0 I get the message File “/tmp/buildpacks/heroku-buildpack-python/vendor/bpwatch/bpwatch.zip/bp_cli.py”, line 37
print get_state()

The problem is that print() is a function in Python3 so the syntax must be print(get_state()) for Python3 to be happy. (e.g. In Python3 the parentheses are not optional).
